### PR TITLE
Fix HTML warning in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Andrei Gaivoronskii</title>
     <link rel="icon" type="image/png" href="/favicon.png">
-    <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;700&amp;display=swap" rel="stylesheet">
     <style>
         body {
             font-family: 'Roboto Mono', monospace;


### PR DESCRIPTION
## Summary
- escape `&display` parameter so `tidy` doesn't report HTML errors
- add missing newline to end of HTML file

## Testing
- `tidy -errors index.html`

------
https://chatgpt.com/codex/tasks/task_e_686aeac5a898832fa76b10acd7ceedd5